### PR TITLE
getoffset of view when SizeChanged

### DIFF
--- a/sdlv/src/main/java/com/yydcdut/sdlv/DragManager.java
+++ b/sdlv/src/main/java/com/yydcdut/sdlv/DragManager.java
@@ -86,6 +86,7 @@ class DragManager implements Callback.OnDragDropListener {
     }
 
     protected void onSizeChanged() {
+        mLeftAndTopOffset = new int[]{0, 0};
         getOffset(mDragListView, mDecorView, mLeftAndTopOffset);
     }
 


### PR DESCRIPTION
When sizeChanged, a new calculation shloud use [0, 0] as a start arguments of getOffset() method. other wise, it go base on a offset last time calculated.